### PR TITLE
Add missing parameter to Restart function, breaking change from 2.7.0

### DIFF
--- a/Source/LivePP2/Private/LivePP2.cpp
+++ b/Source/LivePP2/Private/LivePP2.cpp
@@ -80,7 +80,7 @@ void FLivePP2Module::StartupModule()
 			{
 				// The others don't seem to work. We would need to advance a frame to handle graceful termination,
 				// but this function doesn't return until the process is terminated.
-				GSynchronizedAgent.Restart(lpp::LPP_RESTART_BEHAVIOUR_INSTANT_TERMINATION, 0);
+				GSynchronizedAgent.Restart(lpp::LPP_RESTART_BEHAVIOUR_INSTANT_TERMINATION, 0, nullptr);
 			}
 		}
 	);


### PR DESCRIPTION
2.7.0 - September 10, 2024
==========================

* Breaking API change: The Agent::Restart() API now takes an optional argument for command-line options being passed to the hot-restarted process
